### PR TITLE
Use VS2022 extension for VS2026 and newer

### DIFF
--- a/install-nf-build-components.ps1
+++ b/install-nf-build-components.ps1
@@ -9,6 +9,22 @@ function DownloadVsixFile($fileUrl, $downloadFileName)
     Invoke-WebRequest -Uri $fileUrl -OutFile $downloadFileName
 }
 
+function Get-VSExtensionVersion($vsInstance)
+{
+    # Use the VS2022 extension for VS2022 and any newer release (VS2026 and up),
+    # which it supports. Fall back to VS2019. Returns $null for anything unknown.
+    if($vsInstance -match '20(\d{2})' -and [int]$matches[1] -ge 22)
+    {
+        return '2022'
+    }
+    elseif($vsInstance.Contains('2019'))
+    {
+        return '2019'
+    }
+
+    return $null
+}
+
 "INFO: Downloading extension details" | Write-Host
 
 $usePreview = $env:USE_PREVIEW -eq 'true'
@@ -29,6 +45,10 @@ $VsInstance = $(&$VSWherePath -latest -property displayName)
 
 "INFO: VS is: $VsInstance"  | Write-Host
 
+$vsExtensionVersion = Get-VSExtensionVersion $vsInstance
+
+"INFO: Using VS$vsExtensionVersion extension" | Write-Host
+
 # handle preview version
 if($usePreview -eq $true)
 {
@@ -45,8 +65,7 @@ if($usePreview -eq $true)
 
     # feed list VS2019 and VS2022 extensions using the extension ID
 
-    # VS2022 (also used for VS2026 and newer, which the VS2022 extension supports)
-    if($vsInstance.Contains('2022') -or $vsInstance.Contains('2026'))
+    if($vsExtensionVersion -eq '2022')
     {
         $vs2022Entry = $feedDetails.feed.entry | Where-Object { $_.Vsix.Id -eq $vs2022Id }
 
@@ -61,7 +80,7 @@ if($usePreview -eq $true)
             Write-Host "ERROR: VS2022 extension with ID $vs2022Id not found."
         }
     }
-    elseif($vsInstance.Contains('2019'))
+    elseif($vsExtensionVersion -eq '2019')
     {
         $vs2019Entry = $feedDetails.feed.entry | Where-Object { $_.Vsix.Id -eq $vs2019Id }
 
@@ -120,20 +139,26 @@ else
         $vs2019Tag = $vs2019Release.tag_name
     }
 
-    # Get extension details according to VS version, starting from VS2022 down to VS2019.
-    # VS2026 and newer use the VS2022 extension, which supports them.
-    if($vsInstance.Contains('2022') -or $vsInstance.Contains('2026'))
+    # Get extension details according to VS version.
+    if($vsExtensionVersion -eq '2022')
     {
         $extensionUrl = "https://github.com/nanoframework/nf-Visual-Studio-extension/releases/download/$vs2022Tag/nanoFramework.Tools.VS2022.Extension.vsix"
         $vsixPath = Join-Path $tempDir "nanoFramework.Tools.VS2022.Extension.zip"
         $extensionVersion = $vs2022Tag
     }
-    elseif($vsInstance.Contains('2019'))
+    elseif($vsExtensionVersion -eq '2019')
     {
         $extensionUrl = "https://github.com/nanoframework/nf-Visual-Studio-extension/releases/download/$vs2019Tag/nanoFramework.Tools.VS2019.Extension.vsix"
         $vsixPath = Join-Path $tempDir "nanoFramework.Tools.VS2019.Extension.zip"
         $extensionVersion = $vs2019Tag
     }
+}
+
+# Fail clearly if no extension could be resolved (unknown VS version or missing extension)
+if([string]::IsNullOrWhiteSpace($extensionUrl))
+{
+    Write-Host "ERROR: Unable to determine the nanoFramework extension to install for VS version: $vsInstance"
+    exit 1
 }
 
 # Download VS extension

--- a/install-nf-build-components.ps1
+++ b/install-nf-build-components.ps1
@@ -45,8 +45,8 @@ if($usePreview -eq $true)
 
     # feed list VS2019 and VS2022 extensions using the extension ID
 
-    # VS2022
-    if($vsInstance.Contains('2022'))
+    # VS2022 (also used for VS2026 and newer, which the VS2022 extension supports)
+    if($vsInstance.Contains('2022') -or $vsInstance.Contains('2026'))
     {
         $vs2022Entry = $feedDetails.feed.entry | Where-Object { $_.Vsix.Id -eq $vs2022Id }
 
@@ -120,8 +120,9 @@ else
         $vs2019Tag = $vs2019Release.tag_name
     }
 
-    # Get extension details according to VS version, starting from VS2022 down to VS2019
-    if($vsInstance.Contains('2022'))
+    # Get extension details according to VS version, starting from VS2022 down to VS2019.
+    # VS2026 and newer use the VS2022 extension, which supports them.
+    if($vsInstance.Contains('2022') -or $vsInstance.Contains('2026'))
     {
         $extensionUrl = "https://github.com/nanoframework/nf-Visual-Studio-extension/releases/download/$vs2022Tag/nanoFramework.Tools.VS2022.Extension.vsix"
         $vsixPath = Join-Path $tempDir "nanoFramework.Tools.VS2022.Extension.zip"


### PR DESCRIPTION
## Description
- Route Visual Studio 2026 (and newer) detection through the VS2022 extension in both the stable and preview install paths.
- Previously `vswhere -latest` returning a "Visual Studio ... 2026" display name matched neither the `2022` nor `2019` branch, leaving the extension URL `$null` and failing the download.

## Motivation and Context
GitHub's `windows-latest` image is being redirected to `windows-2025-vs2026` (by 2026-06-15), so `vswhere -latest` now reports Visual Studio 2026 on hosted runners. The action's `install-nf-build-components.ps1` only handled the `2022` and `2019` display names, so setup failed with `Invoke-WebRequest ... Cannot validate argument on parameter 'Uri'. The argument is null or empty`. The VS2022 extension supports VS2026, so routing 2026 through it restores setup.

## How Has This Been Tested?
Verified end-to-end against a real VS2026 runner: the [ccswe-nanoframework/vstest-nanoframework](https://github.com/CCSWE-nanoFramework/vstest-nanoframework) CI was pointed at this branch (`CoryCharlton/nanobuild@fix/support-vs2026`) on `windows-latest` (redirected to `windows-2025-vs2026`). The `Setup nanoFramework` step and the full action test job [passed in ~2 minutes](https://github.com/CCSWE-nanoFramework/vstest-nanoframework/actions/runs/27401018902) — extension downloaded, MSBuild components installed, solution built, and VSTest ran green.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)

## Checklist:
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
